### PR TITLE
Add GET /categories Endpoint

### DIFF
--- a/apps/server/__tests__/unit/category.controller.test.ts
+++ b/apps/server/__tests__/unit/category.controller.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable import/order */
+import request from 'supertest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import createApp from '../../src/app/createApp';
+
+vi.mock('../../src/services/category.service.ts', () => {
+  return {
+    categoryService: {
+      getUserCategories: vi.fn(),
+    },
+  };
+});
+
+import { categoryService } from '../../src/services/category.service.ts';
+
+const app = createApp();
+const TEST_END_POINT = '/api/v1/categories';
+
+describe('Category controller', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 400 when user Id is missing in request params', async () => {
+    const invalidUserId = 'abc'; // Non-numeric user ID
+    const response = await request(app).get(
+      `${TEST_END_POINT}/${invalidUserId}`,
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Invalid user ID format');
+  });
+
+  it('should return 200 and a list of categories when user Id is valid', async () => {
+    const userId = 123;
+    const mockCategories = [
+      { name: 'Rent', id: 1 },
+      { name: 'Groceries', id: 2 },
+    ];
+
+    (
+      categoryService.getUserCategories as ReturnType<typeof vi.fn>
+    ).mockReturnValue(mockCategories);
+
+    const response = await request(app).get(`${TEST_END_POINT}/${userId}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toStrictEqual(mockCategories);
+    expect(categoryService.getUserCategories).toHaveBeenCalledWith(userId);
+  });
+});

--- a/apps/server/__tests__/unit/transaction.controller.test.ts
+++ b/apps/server/__tests__/unit/transaction.controller.test.ts
@@ -1,6 +1,22 @@
 import request from 'supertest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+vi.mock('../../src/middleware/auth.ts', () => {
+  return {
+    // This defines the default export of the mocked module
+    default: vi.fn((req, res, next) => {
+      // auth.ts uses `req.user`, so mock that property
+      req.user = {
+        userId: 123, // Match the type expected (e.g., number)
+        username: 'mockuser',
+        iat: Date.now() / 1000,
+        exp: Date.now() / 1000 + 3600, // Example expiration
+      };
+      next(); // Bypass the actual authentication logic
+    }),
+  };
+});
+
 // eslint-disable-next-line import/order
 import createApp from '../../src/app/createApp';
 

--- a/apps/server/__tests__/unit/user.controller.test.ts
+++ b/apps/server/__tests__/unit/user.controller.test.ts
@@ -1,6 +1,22 @@
 import request from 'supertest';
 import { vi, expect, describe, beforeEach, it } from 'vitest';
 
+vi.mock('../../src/middleware/auth.ts', () => {
+  return {
+    // This defines the default export of the mocked module
+    default: vi.fn((req, res, next) => {
+      // auth.ts uses `req.user`, so mock that property
+      req.user = {
+        userId: 123, // Match the type expected (e.g., number)
+        username: 'mockuser',
+        iat: Date.now() / 1000,
+        exp: Date.now() / 1000 + 3600, // Example expiration
+      };
+      next(); // Bypass the actual authentication logic
+    }),
+  };
+});
+
 vi.mock('../../src/services/user.service.ts', () => {
   return {
     userService: {

--- a/apps/server/src/app/createApp.ts
+++ b/apps/server/src/app/createApp.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import type { Express } from 'express';
 
 import { corsOptions } from '../config/cors';
+import requireAuth from '../middleware/auth';
 import { errorHandler } from '../middleware/globalErrorHandler';
 import authRouter from '../routes/auth.routes';
 import categoryRouter from '../routes/category.routes';
@@ -18,11 +19,11 @@ export default function createApp(): Express {
   app.use(express.json());
   app.use(cors(corsOptions));
 
-  app.use('/api/v1/user', userRouter);
+  app.use('/api/v1/user', requireAuth, userRouter);
   app.use('/api/v1/auth', authRouter);
   app.use('/api/v1/currencies', currencyRouter);
-  app.use('/api/v1/transactions', transactionRouter);
-  app.use('/api/v1/categories', categoryRouter);
+  app.use('/api/v1/transactions', requireAuth, transactionRouter);
+  app.use('/api/v1/categories', requireAuth, categoryRouter);
   app.get('/', (_, res) => {
     res.json({ message: 'Hello World' });
   });

--- a/apps/server/src/app/createApp.ts
+++ b/apps/server/src/app/createApp.ts
@@ -6,6 +6,7 @@ import type { Express } from 'express';
 import { corsOptions } from '../config/cors';
 import { errorHandler } from '../middleware/globalErrorHandler';
 import authRouter from '../routes/auth.routes';
+import categoryRouter from '../routes/category.routes';
 import currencyRouter from '../routes/currency.routes';
 import transactionRouter from '../routes/transaction.routes';
 import userRouter from '../routes/user.routes';
@@ -21,6 +22,7 @@ export default function createApp(): Express {
   app.use('/api/v1/auth', authRouter);
   app.use('/api/v1/currencies', currencyRouter);
   app.use('/api/v1/transactions', transactionRouter);
+  app.use('/api/v1/categories', categoryRouter);
   app.get('/', (_, res) => {
     res.json({ message: 'Hello World' });
   });

--- a/apps/server/src/controllers/category.controller.ts
+++ b/apps/server/src/controllers/category.controller.ts
@@ -1,0 +1,28 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import { categoryService } from '../services/category.service';
+
+export const getUserTransactions = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userIdString = req.params.id;
+    if (!userIdString) {
+      res.status(400).json({ error: 'User ID is required' });
+      return;
+    }
+
+    const userId = parseInt(userIdString, 10);
+    if (isNaN(userId)) {
+      res.status(400).json({ error: 'Invalid user ID format' });
+      return;
+    }
+
+    const response = await categoryService.getUserCategories(userId);
+    res.status(200).json({ data: response });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/apps/server/src/controllers/category.controller.ts
+++ b/apps/server/src/controllers/category.controller.ts
@@ -2,7 +2,7 @@ import type { NextFunction, Request, Response } from 'express';
 
 import { categoryService } from '../services/category.service';
 
-export const getUserTransactions = async (
+export const getUserCategories = async (
   req: Request,
   res: Response,
   next: NextFunction,

--- a/apps/server/src/routes/category.routes.ts
+++ b/apps/server/src/routes/category.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+import { getUserTransactions } from '../controllers/category.controller';
+
+const categoryRouter = Router();
+
+categoryRouter.get('/:id', getUserTransactions);
+
+export default categoryRouter;

--- a/apps/server/src/routes/category.routes.ts
+++ b/apps/server/src/routes/category.routes.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 
-import { getUserTransactions } from '../controllers/category.controller';
+import { getUserCategories } from '../controllers/category.controller';
 
 const categoryRouter = Router();
 
-categoryRouter.get('/:id', getUserTransactions);
+categoryRouter.get('/user/:id', getUserCategories);
 
 export default categoryRouter;

--- a/apps/server/src/schemas/categorySchema.ts
+++ b/apps/server/src/schemas/categorySchema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const categorySchema = z.object({
+  name: z.string().min(1),
+  id: z.number().positive(),
+  user_id: z.number().positive(),
+});
+
+export type Category = z.infer<typeof categorySchema>;

--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -1,0 +1,12 @@
+import prisma from '../database/db';
+import type { Category } from '../schemas/categorySchema';
+
+export const categoryService = {
+  async getUserCategories(userId: number): Promise<Category[]> {
+    return prisma.categories.findMany({
+      where: {
+        user_id: userId,
+      },
+    });
+  },
+};


### PR DESCRIPTION
new GET endpoint for displaying all the categories belong to a specific user. 
For the MVP, all the users will return the same list of categories even tho the endpoint is designed to query categories by userId (to be extensible when users are allowed to create custom categories) 

- added categoryController, categoryService, categoryRouter
- added related unit tests
![image](https://github.com/user-attachments/assets/36faa4b7-830d-4244-9c47-a472f37bcb06)

sample:
<img width="990" alt="image" src="https://github.com/user-attachments/assets/4f751400-0700-40da-a5f9-397456f4d19e" />

